### PR TITLE
Add only as an annotation for the describe/test

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ Use `expect(actual_value)` with assertions:
 
 `skip()`  Declares a skipped test or test group. Test/s is/are never run.
 
+`only()`  Declares an exclusive test or test group that will be executed. If used, all other tests are skipped.
+
 ### `Example↓`
 
 
@@ -167,6 +169,16 @@ Use `expect(actual_value)` with assertions:
 test.skip('description', () => {})
 //or
 describe.skip('description', () => {})
+```
+
+```js
+test.only('description', () => {
+  // Body of the only test that will be executed
+})
+//or
+describe.only('description', () => {
+  // Body of the only test group that will be executed
+})
 ```
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -134,6 +134,8 @@ Use `expect(actual_value)` with assertions:
 
 `skip()`  Declares a skipped test or test group. Test/s is/are never run.
 
+`only()`  Declares an exclusive test or test group that will be executed. If used, all other tests are skipped.
+
 ### `Example↓`
 
 
@@ -141,6 +143,16 @@ Use `expect(actual_value)` with assertions:
 test.skip('description', () => {})
 //or
 describe.skip('description', () => {})
+```
+
+```js
+test.only('description', () => {
+  // Body of the only test that will be executed
+})
+//or
+describe.only('description', () => {
+  // Body of the only test group that will be executed
+})
 ```
 
 ---

--- a/src/core/context.mjs
+++ b/src/core/context.mjs
@@ -59,6 +59,18 @@ export const describe = (name, optionsOrBody, body) => {
   }
 }
 
+describe.only = (name, optionsOrBody, body) => {
+  const options = typeof optionsOrBody === 'object' ? optionsOrBody : {}
+  const actualBody = typeof optionsOrBody === 'function' ? optionsOrBody : body
+  const parentDescribe = currentDescribe
+  currentDescribe = makeDescribe(name, { ...options, focus: true })
+  actualBody()
+  currentDescribe = {
+    ...parentDescribe,
+    children: [...parentDescribe.children, currentDescribe],
+  }
+}
+
 export const test = (name, optionsOrBody, body) => {
   const options = typeof optionsOrBody === 'object' ? optionsOrBody : {}
   const actualBody = typeof optionsOrBody === 'function' ? optionsOrBody : body
@@ -67,6 +79,18 @@ export const test = (name, optionsOrBody, body) => {
     children: [
       ...currentDescribe.children,
       makeTest(name, actualBody, options.timeout, options.tags, options.retry),
+    ],
+  }
+}
+
+test.only = (name, optionsOrBody, body) => {
+  const options = typeof optionsOrBody === 'object' ? optionsOrBody : {}
+  const actualBody = typeof optionsOrBody === 'function' ? optionsOrBody : body
+  currentDescribe = {
+    ...currentDescribe,
+    children: [
+      ...currentDescribe.children,
+      { ...makeTest(name, actualBody, options.timeout, options.tags, options.retry), focus: true },
     ],
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -70,6 +70,37 @@ type Options = {
    * @param callback A callback that is run immediately when calling test(name, optionsOrBody, callback)
    */
   skip(name: string, optionsOrBody: {}, body: {}): void
+    /**
+   * Declares an exclusive test group.
+   * Only the tests in this group are run, and all other tests are skipped.
+   * - `describe.only(title)`
+   * - `describe.only(title, details, callback)`
+   * - `test.only(title, callback)`
+   *
+   * **Usage**
+   *
+   * ```js
+   * describe.only('focused group', () => {
+   *   test('example', () => {
+   *     // This test will run
+   *   });
+   * });
+   * ```
+   * or
+   *
+   * ```js
+   * describe('example', () => {
+   *   test.only('focused test', () => {
+   *     // This test will run
+   *   });
+   * });
+   * ```
+   *
+   * @param name Test title.
+   * @param optionsOrBody (Optional) Object with options
+   * @param callback A callback that is run immediately when calling test(name, optionsOrBody, callback)
+   */
+  only(name: string, optionsOrBody?: {}, body?: {}): void;
 }
 /**
  * Execute before each test case.

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -46,6 +46,28 @@ export const describe = (name, optionsOrBody, body) =>
 describe.skip = (name) => core.skip(name)
 
 /**
+ * Declares an exclusive test group.
+ * Only the tests in this group are run, and all other tests are skipped.
+ * - `describe.only(title)`
+ * - `describe.only(title, details, callback)`
+ *
+ * **Usage**
+ *
+ * ```js
+ * describe.only('focused group', () => {
+ *   test('example', () => {
+ *     // This test will run
+ *   });
+ * });
+ * ```
+ *
+ * @param name Test title.
+ * @param optionsOrBody (Optional) Object with options
+ * @param callback A callback that is run immediately when calling describe.only(name, optionsOrBody, callback)
+ */
+describe.only = (...args) => core.describe.only(...args)
+
+/**
  * Test a specification or test-case with the given title, test options and callback fn.
  *
  * **Usage**
@@ -84,6 +106,25 @@ export const test = (name, optionsOrBody, body) =>
  * @param callback A callback that is run immediately when calling test(name, optionsOrBody, callback)
  */
 test.skip = (name) => core.skip(name)
+
+/**
+ * Declares an exclusive test.
+ * Only this test is executed, while all others are skipped.
+ * - `test.only(title, callback)`
+ *
+ * **Usage**
+ *
+ * ```js
+ * test.only('focused test', () => {
+ *   // This test will run
+ * });
+ * ```
+ *
+ * @param name Test title.
+ * @param optionsOrBody (Optional) Object with options
+ * @param callback A callback that is run immediately when calling test.only(name, optionsOrBody, callback)
+ */
+test.only = (...args) => core.test.only(...args)
 
 /**
  * Execute before each test case.


### PR DESCRIPTION
This feature adds support for the .only annotation in describe and test constructs. It allows running only the selected describe blocks or individual test cases, greatly simplifying the debugging and testing process by focusing on specific parts.

### **Key Changes:**
1. **Support for `describe.only`:**
   - Added functionality to use `describe.only` to execute only a specific `describe` block.
   - All other `describe` blocks will be skipped.

   ```javascript
   describe.only("This block will run", () => {
       test("Test in this block will also run", () => {
           expect(1).toBeEqual(1)
       })
   })
   ```

2. **Support for `test.only`:**
   - Added functionality to use `test.only` to execute a specific `test` within any `describe` block.
   - All other `test` cases in the same or other `describe` blocks will be skipped.

   ```javascript
   describe("Test block", () => {
       test.only("This test will run", () => {
           expect(3).toBeGreaterThan(2)
       })
       test("This test will be skipped", () => {
           expect(true).toBeTruthy()
       })
   })
   ```